### PR TITLE
Return the result of the store.dispatch call to work with async actions like redux-thunk

### DIFF
--- a/src/map-actions.js
+++ b/src/map-actions.js
@@ -3,7 +3,7 @@ const defaultAction = action => function (...args) {
     return
   }
 
-  this.store.dispatch(this.$$actions[action].apply(this, args))
+  return this.store.dispatch(this.$$actions[action].apply(this, args))
 }
 
 const customAction = fn => function (...args) {


### PR DESCRIPTION
Returning the result of the `store.dispatch` call allows callers to wait on the result of async actions, like redux-thunks where the result of the thunk is a Promise. (https://github.com/reduxjs/redux-thunk)

e.g. 
```
methods: {
    ...mapActions('myAction'),
    doThing() {
        const result = await myAction();
    }
}
```