### PR TITLE
update(beforeDestroy): Update beforeDestroy hook to be beforeUnmount

### DIFF
--- a/src/legacy/mixin.ts
+++ b/src/legacy/mixin.ts
@@ -46,7 +46,7 @@ export const connect = ({ app, store, actions = {}, binding = 'store' }) => {
         this.unsubscribe = store.subscribe(syncStateWithComponent(this, this.REDUX_VUEX_BINDINGS))
       }
     },
-    beforeDestroy() {
+    beforeUnmount() {
       this.unsubscribe && this.unsubscribe()
     }
   })


### PR DESCRIPTION
### Issue:
The lifecycle hook `beforeDestroy` which is being used in `src/legacy/mixin.ts` is no longer supported in Vue 3.

### Fix
Updated  `beforeDestroy` to be `beforeUnmount` so that it is Vue3 compatible 



Closes #28