### PR TITLE
Update component data sync for Vue3 internal channges

### DIFF
--- a/src/legacy/mixin.ts
+++ b/src/legacy/mixin.ts
@@ -17,7 +17,7 @@ export const connect = ({ app, store, actions = {}, binding = 'store' }) => {
         return
       }
 
-      set(component._data, prop, getter(state))
+      set(component._.data, prop, getter(state))
     })
   }
 

--- a/src/legacy/mixin.ts
+++ b/src/legacy/mixin.ts
@@ -17,7 +17,7 @@ export const connect = ({ app, store, actions = {}, binding = 'store' }) => {
         return
       }
 
-      set(component._.data, prop, getter(state))
+      set(component, prop, getter(state))
     })
   }
 


### PR DESCRIPTION
The internals of Vue used to have a property on component instances called `_data` on it that contained the reactive variables setup by Vue from a component's `data()` function. The library historically used `_data` when syncing the store bindings to the components state (bindings typically setup by `this.mapState`).

However, in Vue3, all internal properties (fields with leading`_`) were moved from the root of the component instance to instead be nested under a variable called `_`. For example: `component._data` -> `component._.data`. This change was not immediately noticed when the legacy code was included because the Vue3 compat build still exposes the `_data` property to help simplify migration. https://github.com/vuejs/vue-next/blob/ad844cf1e767137a713f715779969ffb94207c7a/packages/runtime-core/src/compat/instance.ts#L143

As such, this change moves the code to using the new internal field. However, it should be **noted that this is not actually necessary**. Given that the reactivity system in Vue3 has changed to use proxies, we could instead place the bindings directly on the `component` instead of `component._.data`.

Is there are particular reason to continue referencing the internal field over syncing directly to the `component`? If there is not a reason, then I can update this to stop using the internal `._.data` field as it isn't a publicly supported API.