### PR TITLE
fix typescript cannot infer from mappedState

### DIFF
--- a/src/map-state.ts
+++ b/src/map-state.ts
@@ -5,7 +5,7 @@ import { injectStore } from './tokens.js'
 import { objectMapper, applyMappers } from './helper.js'
 import { MapOptions, PropertyMappers } from './types.js'
 
-export function mapState<T>(...args: MapOptions) {
+export function mapState<T>(...args: MapOptions): T & Partial<any> {
   const defaultGetter = (prop: string) => (state: { [key: string]: any }) => get(state, prop)
 
   const store = injectStore()
@@ -28,5 +28,5 @@ export function mapState<T>(...args: MapOptions) {
 
   onUnmounted(unsubscribe)
 
-  return bindings as T;
+  return bindings as T
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
   },
-  "include": ["./src/index.ts"]
+  "include": ["./src/*.ts"]
 }


### PR DESCRIPTION
Hello, I encountered some problem when using this package, and tried to resolve it. hope it helps.

1. fix a problem of typescript inferring from mappedState

```
 const mappedState = mapState({
    loading: () => {},
    ...
 });

mappedStgate.loading()
             ^^^^^^ --> Property loading does not exist on type unknown
```

2. fix a problem when build typescript d.ts when this project under parent's node_moudes, which not generates all d.ts.