### PR TITLE
Fix to allow commonjs build for legacy integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "vue": "3.x"
   },
   "module": "./dist/redux-vuex.es.js",
+  "main": "./dist/redux-vuex.cjs.js",
   "types": "./dist/typings/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/redux-vuex.es.js",
+      "require": "./dist/redux-vuex.cjs.js",
       "types": "./dist/typings/index.d.ts"
     }
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig({
   build: {
     lib: {
-      formats: ['es'],
+      formats: ['es', 'cjs'],
       entry: resolve(__dirname, 'src', 'index.ts'),
       name: 'ReduxVuex',
       fileName: (format) => `redux-vuex.${format}.js`,


### PR DESCRIPTION
Jest has currently only experimental support for esm modules and will not transform the module if it is outside of a project folder in a monorepository.