### PR TITLE
Allow usage as plugin

### DIFF
--- a/__tests__/create-store.test.ts
+++ b/__tests__/create-store.test.ts
@@ -1,8 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { createApp } from 'vue'
 import { createStore } from 'redux'
-import { mount } from '@vue/test-utils'
-
 import { injectStore, injectActions } from '../src/tokens'
 import { provide as provideStore } from '../src/provide-store'
 import { reducers, actions } from './store'

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from 'vitest';
+import { createApp } from 'vue'
+import { createStore } from 'redux'
+
+import reduxVuex from '../src/'
+import { injectStore, injectActions } from '../src/tokens'
+import { reducers, actions } from './store'
+
+test('should use store and actions as plugin', () => new Promise<void>((resolve) => {
+  const store = createStore(reducers)
+
+  const TestComponent = {
+    template: '<div>Test Component</div>',
+    props: [],
+    setup() {
+      const reduxStore = injectStore()
+      const storeActions = injectActions()
+
+      expect(reduxStore).toEqual(store)
+      expect(storeActions).toEqual(actions)
+      resolve()
+    }
+  }
+
+  const AppComponent = {
+    template: '<test-component></test-component>',
+    props: [],
+    components: { TestComponent }
+  }
+
+  const app = createApp(AppComponent)
+
+  app.use(reduxVuex(store, actions))
+  app.mount('body')
+}));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import type { App, Plugin } from 'vue'
+import type { ActionCreatorsMapObject, Store } from 'redux'
 import { provide as provideStore } from './provide-store.js'
 import { mapState } from './map-state.js'
 import { mapActions } from './map-actions.js'
@@ -12,4 +14,13 @@ export {
   actionsToken,
   injectStore,
   injectActions
+}
+
+export default function reduxVuex (store: Store, actions?: ActionCreatorsMapObject): Plugin {
+  return {
+    install(app: App) {
+      app.provide(storeToken, store);
+      app.provide(actionsToken, actions);
+    }
+  }
 }


### PR DESCRIPTION
Probably should get a line in the docs as well. I'm not too familiar with the vue Ecosystem so I'd leave it up to you what should be the "preferred" way to use (no pun intended) the lib. Would suggest having one prominent and one as an alternative.